### PR TITLE
Upgrade ng-annotate to 0.5.2 for node 0.12.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-recess": "^1.0.0",
     "gulp-csso": "^0.2.9",
     "gulp-plato": "^1.0.0",
-    "gulp-ng-annotate": "^0.3.0",
+    "gulp-ng-annotate": "^0.5.2",
     "gulp-angular-templatecache": "^1.3.0",
     "karma": "^0.12.21",
     "karma-jasmine": "^0.1.5",


### PR DESCRIPTION
Upgrade ng-annotate to 0.5.2 so it builds with node versions 0.12.x
For more information see https://github.com/olov/ng-annotate/issues/139
